### PR TITLE
fix: off-by-one error

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function extractKey(encodedString) {
 }
 
 function generateKey() {
-	const key = Math.floor(Math.random() * 256) + 1;
+	const key = Math.floor(Math.random() * 256);
 	return [key, hexEncode(key)];
 }
 


### PR DESCRIPTION
`Math.floor(Math.random() * 256) + 1` can result in the key 0x100
In that case `decode(encode('example@example.com'));` outputs `'uqÁÑuuqÁÑuñsá}'`